### PR TITLE
Adds more sites

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -35,7 +35,8 @@
       "http://stackoverflow.com/*",
       "https://stackoverflow.com/*",
       "https://tableless.com.br/*",
-      "https://laracasts.com/discuss/*"
+      "https://laracasts.com/discuss/*",
+      "https://docs.rs/*"
     ]
   }]
 }


### PR DESCRIPTION
A small problem on the rust-lang docs site is that they also have a "Run" button in the top right as well. Everything is still usable, but they overlap slightly. Maybe we can add some alternate positioning in the future based on site? Maybe similar to how `isLargeButton` is handled.