### PR TITLE
Add support for custom domains

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -16,6 +16,26 @@
     "48": "images/icon-48.png",
     "128": "images/icon-128.png"
   },
+  "browser_action": {
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "48": "images/icon-48.png",
+      "128": "images/icon-128.png"
+    }
+  },
+  "permissions": [
+    "contextMenus",
+    "activeTab"
+  ],
+  "optional_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+  "background": {
+    "scripts": [
+      "scripts/background.js"
+    ]
+  },
   "content_scripts": [
     {
       "css": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5472,6 +5472,24 @@
         "xtend": "^4.0.0"
       }
     },
+    "webext-content-script-ping": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webext-content-script-ping/-/webext-content-script-ping-2.0.1.tgz",
+      "integrity": "sha512-37oaeT0GwwkIC8JUD5aToOr0ncdoml/kjZdsn5ckyKyZqpNQHYxhP3NhnqsSx25LpxGfJm8er/IPv9pzCLcfUA=="
+    },
+    "webext-domain-permission-toggle": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/webext-domain-permission-toggle/-/webext-domain-permission-toggle-0.1.0.tgz",
+      "integrity": "sha512-zPwVKYa5EiH0htXedmoAWUaMqU7pOr+4dlzFyGVM64Q0jLVo3V8AVcYOVDKtY+c9qOkhtoSUCGcXCnbs5u8eNg=="
+    },
+    "webext-dynamic-content-scripts": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-5.0.2.tgz",
+      "integrity": "sha512-Y2FMB5Rz29UzQ7eUi9lcNUDeAAhvDDY7Ga1UcCbaHmu6ro3tJpJlzgk7HWaxOBuCtsfFyhZPmitC59n6PGlBFA==",
+      "requires": {
+        "webext-content-script-ping": "^2.0.1"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "dependencies": {
     "clipboard": "2.0.4",
     "primer-buttons": "2.6.1",
-    "primer-tooltips": "1.5.8"
+    "primer-tooltips": "1.5.8",
+    "webext-domain-permission-toggle": "^0.1.0",
+    "webext-dynamic-content-scripts": "^5.0.2"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.9.0",
@@ -22,7 +24,7 @@
   "scripts": {
     "start": "npm run build",
     "build": "npm run build:scripts && npm run build:styles",
-    "build:scripts": "browserify src/scripts/main.js -t [ babelify --presets es2015 ] -o dist/scripts/main.js",
+    "build:scripts": "browserify src/scripts/main.js -t [ babelify --presets es2015 ] -o dist/scripts/main.js && browserify src/scripts/background.js -t [ babelify --presets es2015 ] -o dist/scripts/background.js",
     "build:styles": "node-sass src/styles/main.scss dist/styles/main.css -q --include-path node_modules",
     "watch": "parallelshell 'npm run watch:scripts' 'npm run watch:styles'",
     "watch:scripts": "onchange 'src/scripts/*.js' -- npm run build:scripts",

--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,14 @@ Works with:
 * [npm](https://www.npmjs.com/)
 * [Medium](https://medium.com/)
 
-[And more](https://github.com/zenorocha/codecopy/blob/master/dist/manifest.json#L22).
+[And more](https://github.com/zenorocha/codecopy/blob/7c638611f7ad01d923361f7fedfe3933b35e114c/dist/manifest.json#L27).
 
 If you want to add a new site, feel free to send a pull request :)
+
+### Custom domains
+
+You can also enable CodeCopy on custom domains or Github Enterprise.
+Right click on CodeCopy's icon in the the toolbar  and select **Enable Refined GitHub on this domain**.
 
 ## Preview
 

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,0 +1,5 @@
+import {addContextMenu} from 'webext-domain-permission-toggle';
+import {addToFutureTabs} from 'webext-dynamic-content-scripts';
+
+addToFutureTabs();
+addContextMenu();

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,3 +1,5 @@
+import 'webext-dynamic-content-scripts';
+
 import ClipboardJS from 'clipboard';
 import {htmlButton, getSiteStyle} from './util';
 


### PR DESCRIPTION
Added an option in the context menu under the CodeCopy icon in the toolbar to enable CodeCopy on custom domains and Github Enterprise.

Fixes #27 