### PR TITLE
Add support for Bitrise docs

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -73,7 +73,8 @@
         "https://docs.rs/*",
         "https://www.digitalocean.com/community/*",
         "https://nodejs.org/api/*",
-        "https://css-tricks.com/*"
+        "https://css-tricks.com/*",
+        "https://devcenter.bitrise.io/*"
       ]
     }
   ]


### PR DESCRIPTION
Great extension!
I'd like to add support for https://devcenter.bitrise.io