### PR TITLE
Adding kubernetes.io to matches list

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -59,7 +59,8 @@
         "https://stackoverflow.com/*",
         "https://www.digitalocean.com/community/*",
         "https://nodejs.org/api/*",
-        "https://css-tricks.com/*"
+        "https://css-tricks.com/*",
+        "https://kubernetes.io/*"
       ]
     }
   ]


### PR DESCRIPTION
Kubernets yaml examples should also have copy button.

![codecopy in kube](https://user-images.githubusercontent.com/9607060/108597257-26053c80-7399-11eb-993c-fcd287899564.png)
